### PR TITLE
Meta annotate TestResource

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,38 +4,31 @@ Easily inject file based resources into your jupiter tests
 
 ## Coordinates
 
-Maven POM
-
-```xml
-<dependency>
-  <groupId>com.testingsyndicate</groupId>
-  <artifactId>jupiter-resources-extension</artifactId>
-  <version>x.y.z</version>
-  <scope>test</scope>
-</dependency>
-```
-
-Gradle
-
-```groovy
-testImplementation 'com.testingsyndicate:jupiter-resources-extension:x.y.z'
-```
+See [Releases](https://github.com/testingsyndicate/jupiter-resources-extension/releases) for the latest maven/gradle
+coordinates and version
 
 ## Enabling the extension
 
-You can enable the extension on a per-test class basis using the `@ExtendWith` annotation to register
-the `ResourcesExtension` like so:
+If you are using at least junit v5.8 then you don't need to do anything to enable the extension, you can
+jump straight to [Injecting resources](#injecting-resources)
 
-```java
-@ExtendWith(ResourcesExtension.class)
-class MyTests {
-  // ...
-}
-```
+<details>
+  <summary>I'm using junit &lt; v5.8</summary>
 
-Alternatively the extension also advertises itself for automatic registration, providing you have enabled
-it via setting the property `junit.jupiter.extensions.autodetection.enabled` to `true`.  How you do this
-will differ depending on your build tool.
+  You can enable the extension on a per-test class basis using the `@ExtendWith` annotation to register
+  the `ResourcesExtension` like so:
+
+  ```java
+  @ExtendWith(ResourcesExtension.class)
+  class MyTests {
+    // ...
+  }
+  ```
+
+  Alternatively the extension also advertises itself for automatic registration, providing you have enabled
+  it via setting the property `junit.jupiter.extensions.autodetection.enabled` to `true`.  How you do this
+  will differ depending on your build tool.
+</details>
 
 ## Injecting resources
 

--- a/src/main/java/com/testingsyndicate/jupiter/extensions/resources/TestResource.java
+++ b/src/main/java/com/testingsyndicate/jupiter/extensions/resources/TestResource.java
@@ -4,10 +4,12 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /** Specifies the options for injecting a resource into a test parameter. */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.PARAMETER)
+@ExtendWith(ResourcesExtension.class)
 public @interface TestResource {
   /** Name of the file of the resource to be injected */
   String value();

--- a/src/test/java/com/testingsyndicate/jupiter/extensions/resources/ResourcesExtensionIntegrationTest.java
+++ b/src/test/java/com/testingsyndicate/jupiter/extensions/resources/ResourcesExtensionIntegrationTest.java
@@ -8,10 +8,8 @@ import com.testingsyndicate.jupiter.extensions.resources.TestSupport.TestKitTest
 import java.nio.charset.UnsupportedCharsetException;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.ParameterResolutionException;
 
-@ExtendWith(ResourcesExtension.class)
 class ResourcesExtensionIntegrationTest {
 
   @Nested
@@ -108,7 +106,6 @@ class ResourcesExtensionIntegrationTest {
         .hasCauseInstanceOf(UnsupportedCharsetException.class);
   }
 
-  @ExtendWith(ResourcesExtension.class)
   static class TestStubs {
 
     @TestKitTest

--- a/src/test/java/com/testingsyndicate/jupiter/extensions/resources/resolver/ArchiveResolverTest.java
+++ b/src/test/java/com/testingsyndicate/jupiter/extensions/resources/resolver/ArchiveResolverTest.java
@@ -4,7 +4,6 @@ import static java.util.Collections.list;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 
-import com.testingsyndicate.jupiter.extensions.resources.ResourcesExtension;
 import com.testingsyndicate.jupiter.extensions.resources.TestResource;
 import com.testingsyndicate.jupiter.extensions.resources.resolver.ArchiveResolver.JarFileResolver;
 import java.nio.charset.StandardCharsets;
@@ -12,9 +11,7 @@ import java.util.jar.JarFile;
 import java.util.zip.ZipFile;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 
-@ExtendWith(ResourcesExtension.class)
 class ArchiveResolverTest {
 
   @Nested

--- a/src/test/java/com/testingsyndicate/jupiter/extensions/resources/resolver/ByteArrayResolverTest.java
+++ b/src/test/java/com/testingsyndicate/jupiter/extensions/resources/resolver/ByteArrayResolverTest.java
@@ -3,7 +3,6 @@ package com.testingsyndicate.jupiter.extensions.resources.resolver;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 
-import com.testingsyndicate.jupiter.extensions.resources.ResourcesExtension;
 import com.testingsyndicate.jupiter.extensions.resources.TestResource;
 import com.testingsyndicate.jupiter.extensions.resources.resolver.ByteArrayResolver.BoxedByteArrayResolver;
 import com.testingsyndicate.jupiter.extensions.resources.resolver.ByteArrayResolver.ByteArrayInputStreamResolver;
@@ -12,12 +11,10 @@ import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 
 class ByteArrayResolverTest {
 
   @Nested
-  @ExtendWith(ResourcesExtension.class)
   class PrimitiveByteArrayResolverTest extends AbstractResolverTest {
     private static final PrimitiveByteArrayResolver SUT = new PrimitiveByteArrayResolver();
 
@@ -38,7 +35,6 @@ class ByteArrayResolverTest {
   }
 
   @Nested
-  @ExtendWith(ResourcesExtension.class)
   class BoxedByteArrayResolverTest extends AbstractResolverTest {
     private static final BoxedByteArrayResolver SUT = new BoxedByteArrayResolver();
 
@@ -60,7 +56,6 @@ class ByteArrayResolverTest {
   }
 
   @Nested
-  @ExtendWith(ResourcesExtension.class)
   class ByteArrayInputStreamResolverTest extends AbstractResolverTest {
     private static final ByteArrayInputStreamResolver SUT = new ByteArrayInputStreamResolver();
 

--- a/src/test/java/com/testingsyndicate/jupiter/extensions/resources/resolver/CharArrayResolverTest.java
+++ b/src/test/java/com/testingsyndicate/jupiter/extensions/resources/resolver/CharArrayResolverTest.java
@@ -2,16 +2,13 @@ package com.testingsyndicate.jupiter.extensions.resources.resolver;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.testingsyndicate.jupiter.extensions.resources.ResourcesExtension;
 import com.testingsyndicate.jupiter.extensions.resources.TestResource;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 
 class CharArrayResolverTest {
 
   @Nested
-  @ExtendWith(ResourcesExtension.class)
   class PrimitiveCharArrayResolverTest extends AbstractResolverTest {
     @Test
     void returnsCharArray(@TestResource("wibble.txt") char[] actual) {
@@ -28,7 +25,6 @@ class CharArrayResolverTest {
   }
 
   @Nested
-  @ExtendWith(ResourcesExtension.class)
   class BoxedCharArrayResolverTest extends AbstractResolverTest {
     @Test
     void returnsCharArray(@TestResource("wibble.txt") Character[] actual) {

--- a/src/test/java/com/testingsyndicate/jupiter/extensions/resources/resolver/FileResolverTest.java
+++ b/src/test/java/com/testingsyndicate/jupiter/extensions/resources/resolver/FileResolverTest.java
@@ -3,14 +3,11 @@ package com.testingsyndicate.jupiter.extensions.resources.resolver;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 
-import com.testingsyndicate.jupiter.extensions.resources.ResourcesExtension;
 import com.testingsyndicate.jupiter.extensions.resources.TestResource;
 import java.io.File;
 import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 
-@ExtendWith(ResourcesExtension.class)
 class FileResolverTest extends AbstractResolverTest {
   private static final FileResolver SUT = new FileResolver();
 

--- a/src/test/java/com/testingsyndicate/jupiter/extensions/resources/resolver/InputStreamResolverTest.java
+++ b/src/test/java/com/testingsyndicate/jupiter/extensions/resources/resolver/InputStreamResolverTest.java
@@ -3,14 +3,11 @@ package com.testingsyndicate.jupiter.extensions.resources.resolver;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 
-import com.testingsyndicate.jupiter.extensions.resources.ResourcesExtension;
 import com.testingsyndicate.jupiter.extensions.resources.TestResource;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 
-@ExtendWith(ResourcesExtension.class)
 class InputStreamResolverTest extends AbstractResolverTest {
   private static final InputStreamResolver SUT = new InputStreamResolver();
 

--- a/src/test/java/com/testingsyndicate/jupiter/extensions/resources/resolver/PathResolverTest.java
+++ b/src/test/java/com/testingsyndicate/jupiter/extensions/resources/resolver/PathResolverTest.java
@@ -3,14 +3,11 @@ package com.testingsyndicate.jupiter.extensions.resources.resolver;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 
-import com.testingsyndicate.jupiter.extensions.resources.ResourcesExtension;
 import com.testingsyndicate.jupiter.extensions.resources.TestResource;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 
-@ExtendWith(ResourcesExtension.class)
 class PathResolverTest extends AbstractResolverTest {
   private static final PathResolver SUT = new PathResolver();
 

--- a/src/test/java/com/testingsyndicate/jupiter/extensions/resources/resolver/ScannerResolverTest.java
+++ b/src/test/java/com/testingsyndicate/jupiter/extensions/resources/resolver/ScannerResolverTest.java
@@ -2,13 +2,10 @@ package com.testingsyndicate.jupiter.extensions.resources.resolver;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.testingsyndicate.jupiter.extensions.resources.ResourcesExtension;
 import com.testingsyndicate.jupiter.extensions.resources.TestResource;
 import java.util.Scanner;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 
-@ExtendWith(ResourcesExtension.class)
 class ScannerResolverTest extends AbstractResolverTest {
 
   @Test

--- a/src/test/java/com/testingsyndicate/jupiter/extensions/resources/resolver/StringResolverTest.java
+++ b/src/test/java/com/testingsyndicate/jupiter/extensions/resources/resolver/StringResolverTest.java
@@ -2,14 +2,11 @@ package com.testingsyndicate.jupiter.extensions.resources.resolver;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.testingsyndicate.jupiter.extensions.resources.ResourcesExtension;
 import com.testingsyndicate.jupiter.extensions.resources.TestResource;
 import java.io.StringReader;
 import java.util.Scanner;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 
-@ExtendWith(ResourcesExtension.class)
 class StringResolverTest {
 
   @Test

--- a/src/test/java/com/testingsyndicate/jupiter/extensions/resources/resolver/URIResolverTest.java
+++ b/src/test/java/com/testingsyndicate/jupiter/extensions/resources/resolver/URIResolverTest.java
@@ -3,14 +3,11 @@ package com.testingsyndicate.jupiter.extensions.resources.resolver;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 
-import com.testingsyndicate.jupiter.extensions.resources.ResourcesExtension;
 import com.testingsyndicate.jupiter.extensions.resources.TestResource;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 
-@ExtendWith(ResourcesExtension.class)
 class URIResolverTest extends AbstractResolverTest {
   private static final URIResolver SUT = new URIResolver();
 

--- a/src/test/java/com/testingsyndicate/jupiter/extensions/resources/resolver/URLResolverTest.java
+++ b/src/test/java/com/testingsyndicate/jupiter/extensions/resources/resolver/URLResolverTest.java
@@ -3,14 +3,11 @@ package com.testingsyndicate.jupiter.extensions.resources.resolver;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 
-import com.testingsyndicate.jupiter.extensions.resources.ResourcesExtension;
 import com.testingsyndicate.jupiter.extensions.resources.TestResource;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 
-@ExtendWith(ResourcesExtension.class)
 class URLResolverTest extends AbstractResolverTest {
   private static final URLResolver SUT = new URLResolver();
 


### PR DESCRIPTION
Enables automatic registration of the extension without having to use `@ExtendWith` yourself on each class